### PR TITLE
Fix isCloseToStart

### DIFF
--- a/src/components/BarAndLineChartsWrapper/index.ts
+++ b/src/components/BarAndLineChartsWrapper/index.ts
@@ -324,7 +324,7 @@ export const useBarAndLineChartsWrapper = (
   };
 
   const isCloseToStart = ({ layoutMeasurement, contentOffset }) => {
-    return layoutMeasurement.width + contentOffset.x <= initialSpacing;
+    return contentOffset.x <= initialSpacing;
   };
 
   useEffect(() => {

--- a/src/components/BarAndLineChartsWrapper/index.ts
+++ b/src/components/BarAndLineChartsWrapper/index.ts
@@ -323,7 +323,7 @@ export const useBarAndLineChartsWrapper = (
     );
   };
 
-  const isCloseToStart = ({ layoutMeasurement, contentOffset }) => {
+  const isCloseToStart = ({ contentOffset }) => {
     return contentOffset.x <= initialSpacing;
   };
 


### PR DESCRIPTION
This should fix Issue #1 since it was comparing the width + offset, when it should actually compare just the offset to the initialSpacing. This should work properly and trigger onStartReached callback on react-native-gifted-charts