### PR TITLE
Add RTL support for pagination

### DIFF
--- a/src/components/BarAndLineChartsWrapper/index.ts
+++ b/src/components/BarAndLineChartsWrapper/index.ts
@@ -4,6 +4,7 @@ import {
   BarAndLineChartsWrapperTypes,
   horizSectionPropTypes,
 } from "../../utils/types";
+import { I18nManager } from "react-native";
 
 export const useBarAndLineChartsWrapper = (
   props: BarAndLineChartsWrapperTypes
@@ -318,8 +319,9 @@ export const useBarAndLineChartsWrapper = (
 
   const isCloseToEnd = ({ layoutMeasurement, contentOffset, contentSize }) => {
     return (
-      layoutMeasurement.width + contentOffset.x >=
-      contentSize.width - initialSpacing - endReachedOffset
+      I18nManager.isRTL 
+      ? (contentOffset.x <= initialSpacing) 
+      : (layoutMeasurement.width + contentOffset.x >= contentSize.width - initialSpacing - endReachedOffset)
     );
   };
 
@@ -327,8 +329,11 @@ export const useBarAndLineChartsWrapper = (
   //   return layoutMeasurement.width + contentOffset.x <= initialSpacing;
   // };
 
-  const isCloseToStart = ({ contentOffset }) => {
-    return contentOffset.x <= initialSpacing;
+  const isCloseToStart = ({ layoutMeasurement, contentOffset, contentSize }) => {
+    return (
+      I18nManager.isRTL 
+      ? (layoutMeasurement.width + contentOffset.x >= contentSize.width - initialSpacing - endReachedOffset)
+      : (contentOffset.x <= initialSpacing));
   };
 
   useEffect(() => {


### PR DESCRIPTION
Fixes issue of RTL support where apparently react-native ScrollView contentOffset.x decreases from right to left no matter which direction your device is (RTL/LTR)

Can be tested using this code on `SimpleBarsEndReached.tsx` from `react-native-gifted-charts`
` 
useEffect(() => {
    I18nManager.forceRTL(true);
 }, []);
`