### PR TITLE
Fix read on `undefined` if `animateOnDataChange` is `true`

### DIFF
--- a/src/LineChart/index.ts
+++ b/src/LineChart/index.ts
@@ -462,6 +462,8 @@ export const useLineChart = (props: extendedLineChartPropsType) => {
   if (animateOnDataChange && animations) {
     animations.forEach((item, index) => {
       item.addListener((val) => {
+        if (typeof data[index] === 'undefined') { return; }
+
         const temp = data[index]?.value ?? 0
         data[index].value = val.value
         let pp = ''


### PR DESCRIPTION
The feature `animateOnDataChange` wants to know whether new data is available. However, while doing so, it attempts to read from an `undefined` object if there's, in fact, nothing new to read.

This patch fixes this bug by breaking out of the event listener if an `undefined` array element is found.

For an example, check the screenshot below:

![image](https://github.com/Abhinandan-Kushwaha/gifted-charts-core/assets/3741108/4545558c-7b7e-4661-9374-364d5d130587)

Here's the call stack:

```
item.addListener$argument_0
   node_modules/gifted-charts-core/src/LineChart/index.ts:468:21
__callListeners
   node_modules/react-native-web/dist/vendor/react-native/Animated/nodes/AnimatedNode.js:119:9
__callListeners
   node_modules/react-native-web/dist/vendor/react-native/Animated/nodes/AnimatedWithChildren.js:63:7
__getNativeConfig
   node_modules/react-native-web/dist/vendor/react-native/Animated/nodes/AnimatedValue.js:260:3
animation.start$argument_2
   node_modules/react-native-web/dist/vendor/react-native/Animated/nodes/AnimatedValue.js:225:12
onUpdate
   node_modules/react-native-web/dist/vendor/react-native/Animated/animations/TimingAnimation.js:102:7
```