### PR TITLE
Add verticalLinesStrokeDashArray to axesAndRulesProps

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -711,6 +711,7 @@ export const getAxesAndRulesProps = (
     verticalLinesHeight: props.verticalLinesHeight,
     verticalLinesColor: props.verticalLinesColor,
     verticalLinesShift: props.verticalLinesShift,
+    verticalLinesStrokeDashArray: props.verticalLinesStrokeDashArray,
     verticalLinesZIndex: props.verticalLinesZIndex,
     verticalLinesSpacing: props.verticalLinesSpacing,
     noOfVerticalLines: props.noOfVerticalLines,


### PR DESCRIPTION
This fixes the `verticalLinesStrokeDashArray` prop getting lost when passed to `BarChart` from `react-native-gifted-charts`