### PR TITLE
Add labelWidth prop to stacked bar charts

### DIFF
--- a/src/BarChart/types.ts
+++ b/src/BarChart/types.ts
@@ -23,6 +23,7 @@ export interface stackDataItem {
   onLongPress?: any
   onPressOut?: any
   label?: string
+  labelWidth?: number 
   labelsDistanceFromXaxis?: number
   barWidth?: number
   spacing?: number
@@ -90,6 +91,7 @@ export interface StackedBarChartPropsType {
   onPress?: Function
   onLongPress?: Function
   onPressOut?: Function
+  labelWidth?: number
 
   rotateLabel?: boolean
   showXAxisIndices: boolean


### PR DESCRIPTION
This adds feature parity with bar charts for customizing label widths.