### PR TITLE
Fix BarChart crash when maxValue is 0

### DIFF
--- a/src/BarChart/index.ts
+++ b/src/BarChart/index.ts
@@ -264,7 +264,7 @@ export const useBarChart = (props: extendedBarChartPropsType) => {
     props.stepValue,
     noOfSections,
     maxAndMin.maxItem
-  )
+  ) || 10
 
   const secondaryRange = secondaryMaxItem - secondaryMinPositiveItem // Diff bw largest & smallest +ve values
   const showSecondaryFractionalValues =


### PR DESCRIPTION
This PR fixes a crash caused by BarChart component when the maxValue is 0. This bug was fixed for Line charts in a previous version but was not fixed for Bar Charts.