### PR TITLE
feat: implementation for highlighted/focused mutiple indicies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,16 +15,17 @@
     "@testing-library/jest-dom": "^6.4.8",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.2",
-    "@typescript-eslint/eslint-plugin": "^7.17.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@types/react-native": "^0.73.0",
+    "@typescript-eslint/eslint-plugin": "^7.17.0",
     "eslint": "^8.56.0",
     "eslint-config-love": "^62.0.0",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-n": "^16.6.2",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-react": "^7.33.2",
+    "react-native-svg": "^15.11.2",
     "typescript": "^5.5.4"
   },
   "peerDependencies": {

--- a/src/BarChart/Animated2DWithGradient.ts
+++ b/src/BarChart/Animated2DWithGradient.ts
@@ -14,7 +14,7 @@ interface Animated2dWithGradientPropsType extends BarChartPropsType {
   item: barDataItemNullSafe
   index: number
   barHeight: number
-  selectedIndex: number
+  selectedIndex: number[]
   barBackgroundPattern?: () => ReactNode
   barInnerComponent?: (
     item?: stackDataItem | barDataItem,
@@ -73,7 +73,7 @@ export const getPropsForAnimated2DWithGradient = (
     yAxisOffset
   } = props
 
-  const isFocused = (focusBarOnPress ?? false) && selectedIndex === index
+  const isFocused = (focusBarOnPress ?? false) && selectedIndex.includes(index)
   const itemOrPropsBarBorderRadius =
     item.barBorderRadius ?? barBorderRadius ?? 0
   const localBarBorderRadius =

--- a/src/BarChart/index.ts
+++ b/src/BarChart/index.ts
@@ -59,14 +59,22 @@ export const useBarChart = (props: extendedBarChartPropsType) => {
   const [points, setPoints] = useState('')
   const [points2, setPoints2] = useState('')
   const [arrowPoints, setArrowPoints] = useState('')
-  const [selectedIndex, setSelectedIndex] = useState(focusedBarIndex ?? -1)
+  const [selectedIndex, setSelectedIndex] = useState(() => {
+    if(Array.isArray(focusedBarIndex)) {
+      return focusedBarIndex
+    }
+    return [focusedBarIndex ?? -1]
+  })
   const [selectedStackIndex, setSelectedStackIndex] = useState(
     props.highlightedStackIndex ?? -1
   )
   const showLine = props.showLine ?? BarDefaults.showLine
 
   useEffect(() => {
-    setSelectedIndex(focusedBarIndex ?? -1)
+    const newIndex = Array.isArray(focusedBarIndex)
+      ? focusedBarIndex
+      : [focusedBarIndex?? -1]
+    setSelectedIndex(newIndex)
   }, [focusedBarIndex])
 
   useEffect(() => {

--- a/src/BarChart/types.ts
+++ b/src/BarChart/types.ts
@@ -138,7 +138,7 @@ export interface StackedBarChartPropsType {
   leftShiftForLastIndexTooltip: number
   autoCenterTooltip?: boolean
   initialSpacing: number
-  selectedIndex: number
+  selectedIndex: number[]
   setSelectedIndex: Function
   activeOpacity: number
   showGradient?: boolean
@@ -160,7 +160,7 @@ export interface StackedBarChartPropsType {
   secondaryNoOfSectionsBelowXAxis: number
   containerHeightIncludingBelowXAxis: number
   highlightEnabled: boolean
-  highlightedBarIndex: number
+  highlightedBarIndex: number|number[]
   lowlightOpacity: number
   stackHighlightEnabled?: boolean
   selectedStackIndex: number
@@ -373,10 +373,10 @@ export interface BarChartPropsType {
 
   focusBarOnPress?: boolean
   focusedBarConfig?: FocusedBarConfig
-  focusedBarIndex?: number
+  focusedBarIndex?: number|number[]
 
   highlightEnabled?: boolean // highlights Bar on press in react-native and on on hover in react-js
-  highlightedBarIndex?: number
+  highlightedBarIndex?: number|number[]
   lowlightOpacity?: number
 
   stackHighlightEnabled?: boolean
@@ -662,14 +662,14 @@ export interface RenderBarsPropsType {
   autoCenterTooltip?: boolean
   leftShiftForLastIndexTooltip: number
   initialSpacing: number
-  selectedIndex: number
+  selectedIndex: number[]
   setSelectedIndex: Function
   barStyle?: object
   xAxisThickness?: number
   secondaryXAxis?: XAxisConfig
   pointerConfig?: Pointer
   focusBarOnPress?: boolean
-  focusedBarIndex?: number
+  focusedBarIndex?: number|number[]
   noOfSectionsBelowXAxis?: number
   yAxisOffset: number
   stepHeight: number
@@ -682,7 +682,7 @@ export interface RenderBarsPropsType {
   secondaryNegativeStepValue: number
   secondaryNoOfSectionsBelowXAxis: number
   highlightEnabled: boolean
-  highlightedBarIndex: number
+  highlightedBarIndex: number|number[]
   lowlightOpacity: number
 }
 
@@ -720,7 +720,7 @@ export interface animatedBarPropTypes {
   barStyle?: object
   item: barDataItem
   index: number
-  selectedIndex: number
+  selectedIndex: number[]
   focusBarOnPress?: boolean
   focusedBarConfig?: FocusedBarConfig
 }

--- a/src/LineChart/LineChartBiColor.ts
+++ b/src/LineChart/LineChartBiColor.ts
@@ -477,7 +477,7 @@ export const useLineChartBiColor = (
     scrollAnimation,
     scrollEventThrottle,
     indicatorColor: props.indicatorColor,
-    selectedIndex,
+    selectedIndex: [selectedIndex],
     setSelectedIndex,
     spacing,
     showLine: false,

--- a/src/LineChart/index.ts
+++ b/src/LineChart/index.ts
@@ -2167,7 +2167,7 @@ export const useLineChart = (props: extendedLineChartPropsType) => {
     scrollAnimation,
     scrollEventThrottle,
     indicatorColor: props.indicatorColor,
-    selectedIndex,
+    selectedIndex: [selectedIndex],
     setSelectedIndex,
     spacing,
     showLine: false,

--- a/src/components/AnimatedThreeDBar/index.ts
+++ b/src/components/AnimatedThreeDBar/index.ts
@@ -6,7 +6,7 @@ import { getBarSideColor, getBarTopColor } from '../../utils'
 export const useAnimatedThreeDBar = (props: animatedBarPropTypes) => {
   const { focusBarOnPress, index, selectedIndex, focusedBarConfig, item } =
     props
-  const isFocused = focusBarOnPress && index === selectedIndex
+  const isFocused = focusBarOnPress && selectedIndex.includes(index)
   const localFrontColor = props.frontColor || BarDefaults.threeDBarFrontColor
   const localGradientColor =
     props.gradientColor || BarDefaults.threeDBarGradientColor

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -169,7 +169,7 @@ export interface LineInBarChartPropsType {
   labelsExtraHeight: number
   scrollEventThrottle: number
   xAxisLabelsVerticalShift: number
-  selectedIndex: number
+  selectedIndex: number[]
   yAxisOffset: number
   strokeDashArray: number[]
   highlightEnabled: boolean
@@ -326,7 +326,7 @@ export interface BarAndLineChartsWrapperTypes {
   scrollToIndex: number | undefined
   scrollAnimation: boolean
   indicatorColor: 'black' | 'default' | 'white' | undefined
-  selectedIndex: number
+  selectedIndex: number[]
   setSelectedIndex: any
   spacing: number
   showLine: boolean


### PR DESCRIPTION
### What
- Includes adding `react-native-svg` in the dev dependencies for successful builds
- make `selectedIndex` an array of numbers
- if `focusedIndex` is passed check if its an array of number or number and then set `selectedIndex`
- update the type definitions of the `focusedIndex` and `highlightedBarIndex`

### Notes
- These changes are only for bar-chart and not the others.

Would resolve the issue https://github.com/Abhinandan-Kushwaha/react-native-gifted-charts/issues/1083