### PR TITLE
feat: add props for spread in line chart

### DIFF
--- a/src/LineChart/types.ts
+++ b/src/LineChart/types.ts
@@ -564,6 +564,10 @@ export interface LineChartBicolorPropsType {
   verticalLinesSpacing?: number
   hideAxesAndRules?: boolean
   areaChart?: boolean
+  
+  spreadAreaData?: { lower: number; upper: number }[];
+  spreadAreaColor?: string;
+  spreadAreaOpacity?: number;
 
   disableScroll?: boolean
   showScrollIndicator?: boolean


### PR DESCRIPTION
# Add Spread Area/Band Functionality to Line Charts

This PR adds the ability to display spread areas (confidence bands, error bands, etc.) on line charts, providing visual representation of data ranges or uncertainty bounds. Note that this PR is related to this [PR](<https://github.com/Abhinandan-Kushwaha/react-native-gifted-charts/pull/1104>) on gifted-charts. Thanks [@TirelessDev](<https://github.com/TirelessDev>) for helping with this!

## New Features

### Line Chart Props

| Prop Name | Type | Description | Default |
|-----------|------|-------------|---------|
| `spreadAreaData` | `Array<{lower: number; upper: number}>` | Array of objects defining lower and upper bounds for each data point to create a spread/band area | `undefined` |
| `spreadAreaColor` | `ColorValue` | Color of the spread area/band | `'lightgray'` |
| `spreadAreaOpacity` | `number` | Opacity of the spread area (0-1) | `0.3` |

### Usage Example

```typescript
const chartData = [
  { value: 10 },
  { value: 20 },
  { value: 15 },
  { value: 25 }
];

const spreadData = [
  { lower: 8, upper: 12 },
  { lower: 18, upper: 22 },
  { lower: 13, upper: 17 },
  { lower: 23, upper: 27 }
];

<LineChart
  data={chartData}
  spreadAreaData={spreadData}
  spreadAreaColor="rgba(100, 150, 200, 0.3)"
  spreadAreaOpacity={0.4}
/>
```

### Visual Preview

The spread area creates a filled region between the upper and lower bounds, providing context for data variability or confidence intervals.

<img width="303" alt="Screenshot 2025-06-09 at 9 07 22 PM" src="https://github.com/user-attachments/assets/e71fa409-dd08-43c7-92bd-eae2c5f71c79" />

### Breaking Changes

None - this is a purely additive feature with optional props.