### PR TITLE
feat(BubbleChart): stable axis normalisation and edge spacing

### DIFF
--- a/src/BubbleChart/index.ts
+++ b/src/BubbleChart/index.ts
@@ -23,6 +23,11 @@ import {
   RegressionLineCoordinates
 } from '../utils/types'
 import { BubbleChartPropsType, bubbleDataItem } from './types'
+import {
+  computeAxisSections,
+  getBubbleMode,
+  getNormalizedXAxisLayout
+} from '../utils/bubbleChartUtils'
 import { Dimensions } from 'react-native'
 
 export interface extendedBubbleChartPropsType extends BubbleChartPropsType {
@@ -69,22 +74,53 @@ export const useBubbleChart = (props: extendedBubbleChartPropsType) => {
   const maxRadius =
     props.maxRadius ?? Math.min(containerHeight, props.width ?? Infinity) / 5
 
+  // ── Auto axis computation ────────────────────────────────────────────────
+  // Build a series array from whatever data the caller provided so that
+  // computeAxisSections / getNormalizedXAxisLayout can work with it.
+  // Explicit props always take precedence via the ?? fallbacks below.
+  const seriesForAxisCalc = dataSet
+    ? dataSet.map(s => ({
+        data: s.data.map(item => ({
+          x: item.x ?? 0,
+          y: item.y ?? 0,
+          r: item.r
+        }))
+      }))
+    : [{ data: data.map(item => ({ x: item.x ?? 0, y: item.y ?? 0, r: item.r })) }]
+
+  const isBubbleMode = getBubbleMode(
+    seriesForAxisCalc,
+    props.scatterChart ? 'scatter' : 'bubble'
+  )
+
+  const derivedAxes = computeAxisSections(seriesForAxisCalc, props.width)
+
+  const derivedXLayout = getNormalizedXAxisLayout({
+    normalizedAxes: derivedAxes,
+    series: seriesForAxisCalc,
+    bubbleMode: isBubbleMode,
+    chartWidth: props.width ?? screenWidth,
+    minBubbleRadius: minRadius,
+    maxBubbleRadius: maxRadius
+  })
+  // ─────────────────────────────────────────────────────────────────────────
+
   let xRange =
     Math.max(...data.map((i: any) => Math.max(i.x ?? 0, 0))) - // find the largest +ve number
       Math.min(...data.map((i: any) => Math.max(i.x ?? 0, 0))) || // find the smallest +ve number
     data.length
 
   const xNoOfSections = getNoOfSections(
-    props.xNoOfSections,
+    props.xNoOfSections ?? derivedXLayout.xNoOfSections,
     props.maxX,
     props.xStepValue,
     true
   )
 
-  const initialSpacing = props.initialSpacing ?? BubbleDefaults.initialSpacing
+  const initialSpacing = props.initialSpacing ?? derivedXLayout.initialSpacing
   const spacing =
     props.spacing ??
-    (props.width ? props.width / xNoOfSections : LineDefaults.spacing)
+    (props.width ? derivedXLayout.spacing : LineDefaults.spacing)
 
   const showFractionalXAxis =
     props.showFractionalXAxis ??
@@ -93,7 +129,7 @@ export const useBubbleChart = (props: extendedBubbleChartPropsType) => {
     props.xRoundToDigits ??
     (showFractionalXAxis ? indexOfFirstNonZeroDigit(xRange) + 1 : 0)
 
-  const endSpacing = props.endSpacing ?? BubbleDefaults.endSpacing
+  const endSpacing = props.endSpacing ?? derivedXLayout.endSpacing
 
   const totalWidth = initialSpacing + spacing * xNoOfSections + endSpacing
 

--- a/src/utils/bubbleChartUtils.test.ts
+++ b/src/utils/bubbleChartUtils.test.ts
@@ -1,0 +1,401 @@
+import {
+  computeAxisSections,
+  formatLabel,
+  getBubbleMode,
+  getNormalizedXAxisLayout,
+  getRenderedXValue,
+  normalizeAxis,
+  normalizeAxisLabelValue,
+} from './bubbleChartUtils';
+
+describe('bubbleChartUtils', () => {
+  // -------------------------------------------------------------------------
+  describe('normalizeAxis', () => {
+    it('uses 25-step intervals for mid-range values (highcharts-like)', () => {
+      const axis = normalizeAxis(20, 126.4, 5);
+
+      expect(axis.tickInterval).toBe(25);
+      expect(axis.min).toBe(0);
+      expect(axis.max).toBe(150);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('computeAxisSections', () => {
+    it('returns defaults for empty series', () => {
+      const result = computeAxisSections([]);
+
+      expect(result.xSections).toBe(5);
+      expect(result.ySections).toBe(5);
+      expect(result.dataBounds.x.min).toBe(0);
+      expect(result.dataBounds.x.max).toBe(100);
+      expect(result.dataBounds.y.min).toBe(0);
+      expect(result.dataBounds.y.max).toBe(100);
+    });
+
+    it('returns exact raw data bounds for x and y', () => {
+      const series = [
+        {
+          data: [
+            { x: 3, y: 10 },
+            { x: -5, y: 7 },
+            { x: 12, y: -4 },
+          ],
+        },
+        {
+          data: [
+            { x: 0, y: 20 },
+            { x: 8, y: -10 },
+          ],
+        },
+      ];
+
+      const result = computeAxisSections(series);
+
+      expect(result.dataBounds.x.min).toBe(-5);
+      expect(result.dataBounds.x.max).toBe(12);
+      expect(result.dataBounds.y.min).toBe(-10);
+      expect(result.dataBounds.y.max).toBe(20);
+    });
+
+    it('increases x sections for wider chart widths', () => {
+      const series = [
+        {
+          data: Array.from({ length: 11 }, (_, i) => ({
+            x: i * 10,
+            y: i + 1,
+          })),
+        },
+      ];
+
+      const narrowResult = computeAxisSections(series, 220);
+      const wideResult = computeAxisSections(series, 620);
+
+      expect(wideResult.xSections).toBeGreaterThan(narrowResult.xSections);
+    });
+
+    it('caps x sections at 5 for high-cardinality data', () => {
+      const series = [
+        {
+          data: Array.from({ length: 40 }, (_, i) => ({
+            x: i,
+            y: i + 1,
+          })),
+        },
+      ];
+
+      const result = computeAxisSections(series, 1200);
+
+      expect(result.xSections).toBeLessThanOrEqual(5);
+    });
+
+    it('caps x sections for tight integer domains to avoid repeated integer labels', () => {
+      const series = [
+        {
+          data: [
+            { x: 1, y: 2 },
+            { x: 2, y: 3 },
+            { x: 3, y: 4 },
+          ],
+        },
+      ];
+
+      const result = computeAxisSections(series, 620);
+
+      expect(result.dataBounds.x.min).toBe(1);
+      expect(result.dataBounds.x.max).toBe(3);
+      expect(result.xSections).toBeLessThanOrEqual(2);
+    });
+
+    it('uses unique low-cardinality uniform x buckets to avoid extra trailing section', () => {
+      const series = [
+        {
+          data: [
+            { x: 1.0000000001, y: 2 },
+            { x: 2, y: 3 },
+            { x: 3.0000000002, y: 4 },
+          ],
+        },
+      ];
+
+      const result = computeAxisSections(series, 620);
+
+      expect(result.xSections).toBe(2);
+      expect(result.dataBounds.x.min).toBe(1);
+      expect(result.dataBounds.x.max).toBe(3);
+    });
+
+    it('snaps near-integer x values to integer buckets', () => {
+      const series = [
+        {
+          data: [
+            { x: 1.02, y: 2 },
+            { x: 2.01, y: 3 },
+            { x: 3.1, y: 4 },
+          ],
+        },
+      ];
+
+      const result = computeAxisSections(series, 620);
+
+      expect(result.xSections).toBe(2);
+      expect(result.xLabelsAsIntegers).toBe(true);
+      expect(result.dataBounds.x.min).toBe(1);
+      expect(result.dataBounds.x.max).toBe(3);
+    });
+
+    it('uses canonical nice Y intervals instead of odd nearest steps', () => {
+      const series = [
+        {
+          data: [
+            { x: 10, y: 30 },
+            { x: 40, y: 65 },
+            { x: 90, y: 50 },
+          ],
+        },
+      ];
+
+      const result = computeAxisSections(series, 320);
+
+      expect(result.yAxis.tickInterval).toBe(10);
+      expect(result.yAxis.min).toBe(30);
+      expect(result.yAxis.max).toBe(70);
+      expect(result.ySections).toBe(4);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('getBubbleMode', () => {
+    it('respects explicit chart type', () => {
+      expect(getBubbleMode([], 'scatter')).toBe(false);
+      expect(getBubbleMode([], 'bubble')).toBe(true);
+    });
+
+    it('infers bubble mode from point radius when chart type is undefined', () => {
+      expect(
+        getBubbleMode([
+          { data: [{ x: 1, y: 2 }] },
+          { data: [{ x: 2, y: 3, r: 12 }] },
+        ]),
+      ).toBe(true);
+      expect(getBubbleMode([{ data: [{ x: 1, y: 2 }] }])).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('formatLabel', () => {
+    it('truncates scatter labels longer than 4 chars to first 3 plus ellipsis', () => {
+      expect(formatLabel('Organic', 5, false)).toBe('Org...');
+      expect(formatLabel('Blue Goose', 5, false)).toBe('Blu...');
+    });
+
+    it('keeps short scatter labels unchanged', () => {
+      expect(formatLabel('Item', 5, false)).toBe('Item');
+      expect(formatLabel('AB', 5, false)).toBe('AB');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('getRenderedXValue', () => {
+    it('returns raw x when integer label mode is disabled', () => {
+      expect(getRenderedXValue(2.17, false)).toBe(2.17);
+    });
+
+    it('snaps to nearest integer when within tolerance', () => {
+      expect(getRenderedXValue(1.02, true)).toBe(1);
+      expect(getRenderedXValue(2.01, true)).toBe(2);
+      expect(getRenderedXValue(3.1, true)).toBe(3);
+    });
+
+    it('keeps raw value when outside integer snap tolerance', () => {
+      expect(getRenderedXValue(3.21, true)).toBe(3.21);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('normalizeAxisLabelValue', () => {
+    it('keeps non-numeric values unchanged', () => {
+      expect(
+        normalizeAxisLabelValue({ value: 'abc', tickInterval: 25 }),
+      ).toBe('abc');
+    });
+
+    it('uses integer labels when requested', () => {
+      expect(
+        normalizeAxisLabelValue({
+          value: '2.9999',
+          tickInterval: 1,
+          labelsAsIntegers: true,
+        }),
+      ).toBe('3');
+    });
+
+    it('normalizes very close decimal values with interval-aware precision', () => {
+      expect(
+        normalizeAxisLabelValue({ value: '1.23444', tickInterval: 0.01 }),
+      ).toBe('1.234');
+      expect(
+        normalizeAxisLabelValue({ value: '1.23555', tickInterval: 0.01 }),
+      ).toBe('1.236');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('getNormalizedXAxisLayout', () => {
+    it('returns integer-snapped layout and full-width spacing', () => {
+      const normalizedAxes = computeAxisSections(
+        [
+          {
+            data: [
+              { x: 1.02, y: 2 },
+              { x: 2.01, y: 3 },
+              { x: 3.1, y: 4 },
+            ],
+          },
+        ],
+        320,
+      );
+
+      const layout = getNormalizedXAxisLayout({
+        normalizedAxes,
+        series: [
+          {
+            data: [
+              { x: 1.02, y: 2, r: 14 },
+              { x: 2.01, y: 3, r: 16 },
+            ],
+          },
+        ],
+        bubbleMode: true,
+        chartWidth: 320,
+        minBubbleRadius: 5,
+        maxBubbleRadius: 20,
+      });
+
+      expect(layout.xAxisMin).toBe(1);
+      expect(layout.xAxisMax).toBe(3);
+      expect(layout.xNoOfSections).toBe(2);
+      expect(layout.initialSpacing).toBe(16);
+      expect(layout.endSpacing).toBe(18);
+      expect(layout.spacing).toBeCloseTo((320 - 34) / 2);
+    });
+
+    it('uses radius-based edge spacing in scatter mode to avoid clipping', () => {
+      const series = [
+        {
+          data: [
+            { x: 1, y: 10 },
+            { x: 2, y: 20 },
+            { x: 3, y: 30 },
+            { x: 4, y: 40 },
+          ],
+        },
+      ];
+      const normalizedAxes = computeAxisSections(series, 120);
+
+      const chartWidth = 120;
+      const minBubbleRadius = 5;
+
+      const layout = getNormalizedXAxisLayout({
+        normalizedAxes,
+        series,
+        bubbleMode: false,
+        chartWidth,
+        minBubbleRadius,
+        maxBubbleRadius: 20,
+      });
+
+      expect(normalizedAxes.xLabelsAsIntegers).toBe(true);
+      expect(layout.initialSpacing).toBe(minBubbleRadius);
+      expect(layout.endSpacing).toBe(minBubbleRadius);
+      expect(
+        layout.spacing * layout.xNoOfSections +
+          layout.initialSpacing +
+          layout.endSpacing,
+      ).toBe(chartWidth);
+    });
+
+    it('keeps sparse integer domains on coarse sections (e.g. 5, 15, 25)', () => {
+      const series = [
+        {
+          data: [
+            { x: 5, y: 10 },
+            { x: 15, y: 30 },
+            { x: 25, y: 50 },
+          ],
+        },
+      ];
+
+      const normalizedAxes = computeAxisSections(series, 320);
+      const layout = getNormalizedXAxisLayout({
+        normalizedAxes,
+        series,
+        bubbleMode: false,
+        chartWidth: 320,
+        minBubbleRadius: 5,
+        maxBubbleRadius: 20,
+      });
+
+      expect(normalizedAxes.xLabelsAsIntegers).toBe(true);
+      expect(normalizedAxes.xSections).toBe(2);
+      expect(layout.xAxisMin).toBe(5);
+      expect(layout.xAxisMax).toBe(25);
+      expect(layout.xNoOfSections).toBe(2);
+      expect(layout.xStepValue).toBe(10);
+    });
+
+    it('uses raw x-domain bounds for dense ranges without artificial rounding', () => {
+      const series = [
+        {
+          data: Array.from({ length: 20 }, (_, i) => ({
+            x: i + 1,
+            y: (i + 1) * 5,
+          })),
+        },
+      ];
+
+      const normalizedAxes = computeAxisSections(series, 360);
+      const layout = getNormalizedXAxisLayout({
+        normalizedAxes,
+        series,
+        bubbleMode: false,
+        chartWidth: 360,
+        minBubbleRadius: 5,
+        maxBubbleRadius: 20,
+      });
+
+      expect(normalizedAxes.xLabelsAsIntegers).toBe(false);
+      expect(layout.xAxisMin).toBe(1);
+      expect(layout.xAxisMax).toBe(20);
+      expect(layout.xStepValue).toBe(4.75);
+    });
+
+    it('keeps non-uniform sparse x labels on clean intervals without drift', () => {
+      const series = [
+        {
+          data: [
+            { x: 20, y: 4, r: 10 },
+            { x: 40, y: 6, r: 20 },
+            { x: 30, y: 8, r: 60 },
+            { x: 120, y: 5, r: 40 },
+          ],
+        },
+      ];
+
+      const normalizedAxes = computeAxisSections(series, 360);
+      const layout = getNormalizedXAxisLayout({
+        normalizedAxes,
+        series,
+        bubbleMode: true,
+        chartWidth: 360,
+        minBubbleRadius: 5,
+        maxBubbleRadius: 20,
+      });
+
+      expect(layout.xStepValue).toBe(20);
+      expect(layout.xAxisMin).toBe(20);
+      expect(layout.xAxisMax).toBe(120);
+      expect(layout.xNoOfSections).toBe(5);
+    });
+  });
+});

--- a/src/utils/bubbleChartUtils.ts
+++ b/src/utils/bubbleChartUtils.ts
@@ -1,0 +1,571 @@
+/**
+ * bubbleChartUtils.ts
+ *
+ * Pure chart-math utilities for bubble and scatter charts.
+ * No React, no React Native, no external dependencies.
+ *
+ * Public API
+ * ----------
+ * normalizeAxis           – "nice" tick intervals for a single axis
+ * computeAxisSections     – scan multi-series data → stable X/Y bounds + tick counts
+ * getNormalizedXAxisLayout– turn axis bounds into explicit BubbleChart layout props
+ * normalizeAxisLabelValue – round a label string to interval-aware precision
+ * getBubbleMode           – infer bubble vs scatter from data or explicit prop
+ * getRenderedXValue       – integer-snap a point's X when the domain is categorical
+ * formatLabel             – radius-proportional label truncation for in-bubble text
+ */
+
+// ---------------------------------------------------------------------------
+// Internal configuration
+// ---------------------------------------------------------------------------
+
+const CHART_CONFIG = {
+  label: {
+    minChars: 3,
+    charsPerRadiusUnit: 0.3,
+    radiusBuffer: 5,
+  },
+  axis: {
+    defaultSections: 5,
+    minYSections: 2,
+    minXSections: 1,
+    maxSections: 5,
+    defaultTickPixelInterval: 100,
+    floatTolerance: 1e-6,
+    integerSnapTolerance: 0.15,
+  },
+  spacing: {
+    bubbleBuffer: 2,
+  },
+} as const;
+
+const MAX_X_TICKS_FROM_SECTION_CAP = CHART_CONFIG.axis.maxSections + 1;
+const DEFAULT_TICK_COUNT = CHART_CONFIG.axis.defaultSections + 1;
+
+// Canonical "nice number" progression for stable axis steps (Highcharts-style).
+const CANONICAL_TICK_MULTIPLES = [1, 2, 2.5, 5, 10] as const;
+
+const getCeilCanonicalMultiple = (value: number): number =>
+  CANONICAL_TICK_MULTIPLES.find((m) => m >= value) ??
+  CANONICAL_TICK_MULTIPLES[CANONICAL_TICK_MULTIPLES.length - 1];
+
+const getNearestCanonicalMultiple = (value: number): number =>
+  CANONICAL_TICK_MULTIPLES.reduce((best, candidate) =>
+    Math.abs(candidate - value) < Math.abs(best - value) ? candidate : best,
+  );
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.max(min, Math.min(max, value));
+
+const getTargetTickCountByWidth = (
+  axisLengthPx: number,
+  tickPixelInterval: number = CHART_CONFIG.axis.defaultTickPixelInterval,
+): number => {
+  if (!Number.isFinite(axisLengthPx) || axisLengthPx <= 0) {
+    return DEFAULT_TICK_COUNT;
+  }
+  return Math.max(2, Math.ceil(axisLengthPx / tickPixelInterval) + 1);
+};
+
+const getIntegerDomainSectionCap = (min: number, max: number): number => {
+  const roundedMin = Math.round(min);
+  const roundedMax = Math.round(max);
+  const minIsIntegerLike =
+    Math.abs(min - roundedMin) <= CHART_CONFIG.axis.floatTolerance;
+  const maxIsIntegerLike =
+    Math.abs(max - roundedMax) <= CHART_CONFIG.axis.floatTolerance;
+
+  if (!minIsIntegerLike || !maxIsIntegerLike) return Number.POSITIVE_INFINITY;
+
+  const span = Math.abs(roundedMax - roundedMin);
+  if (span === 0) return CHART_CONFIG.axis.minXSections;
+
+  return Math.max(CHART_CONFIG.axis.minXSections, Math.floor(span));
+};
+
+const isNearUniformSpacing = (sortedValues: number[]): boolean => {
+  if (sortedValues.length < 3) return true;
+
+  const deltas: number[] = [];
+  for (let i = 1; i < sortedValues.length; i++) {
+    deltas.push(sortedValues[i] - sortedValues[i - 1]);
+  }
+
+  const minDelta = Math.min(...deltas);
+  const maxDelta = Math.max(...deltas);
+
+  if (minDelta <= 0) return false;
+  return maxDelta / minDelta <= 1.2;
+};
+
+const getDecimalsFromInterval = (tickInterval: number): number => {
+  if (
+    !Number.isFinite(tickInterval) ||
+    tickInterval <= 0 ||
+    tickInterval >= 1
+  ) {
+    return 0;
+  }
+  // Preserve one extra decimal over interval precision to avoid collapsing
+  // close labels while still removing floating-point noise.
+  const intervalDecimals = Math.ceil(-Math.log10(tickInterval));
+  return clamp(intervalDecimals + 1, 1, 6);
+};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Minimal series shape consumed by these utilities. */
+type TSeriesPoint = { x: number; y: number; r?: number };
+type TSeries = { data: TSeriesPoint[] };
+
+/** Normalised axis metadata returned by computeAxisSections. */
+export type TAxisSections = {
+  xSections: number;
+  ySections: number;
+  yAxis: { min: number; max: number; tickInterval: number; tickCount: number };
+  xLabelsAsIntegers: boolean;
+  dataBounds: {
+    x: { min: number; max: number };
+    y: { min: number; max: number };
+  };
+};
+
+/** Input for getNormalizedXAxisLayout. */
+type TXAxisLayoutInput = {
+  normalizedAxes: TAxisSections;
+  series: TSeries[];
+  bubbleMode: boolean;
+  chartWidth: number;
+  minBubbleRadius: number;
+  maxBubbleRadius: number;
+};
+
+/** Explicit BubbleChart layout props produced by getNormalizedXAxisLayout. */
+export type TXAxisLayout = {
+  xAxisMin: number;
+  xAxisMax: number;
+  xNoOfSections: number;
+  xStepValue: number;
+  xAxisOffset: number;
+  initialSpacing: number;
+  endSpacing: number;
+  spacing: number;
+};
+
+type TAxisLabelNormalizationInput = {
+  value: string;
+  tickInterval: number;
+  labelsAsIntegers?: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Default result (used when series is empty)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_AXIS_RESULT: TAxisSections = {
+  xSections: CHART_CONFIG.axis.defaultSections,
+  ySections: CHART_CONFIG.axis.defaultSections,
+  yAxis: {
+    min: 0,
+    max: 100,
+    tickInterval: 100 / (DEFAULT_TICK_COUNT - 1),
+    tickCount: DEFAULT_TICK_COUNT,
+  },
+  xLabelsAsIntegers: false,
+  dataBounds: {
+    x: { min: 0, max: 100 },
+    y: { min: 0, max: 100 },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute "nice" min/max bounds and a stable tick interval for one axis.
+ *
+ * Uses the canonical 1 / 2 / 2.5 / 5 / 10 progression so that step values
+ * are always human-readable (e.g. 25 instead of 26.8).
+ */
+export const normalizeAxis = (
+  min: number,
+  max: number,
+  targetTickCount: number = DEFAULT_TICK_COUNT,
+  options?: { preferLargerInterval?: boolean },
+): { min: number; max: number; tickInterval: number; tickCount: number } => {
+  if (min === max) {
+    const padding = Math.abs(min) * 0.1 || 1;
+    return {
+      min: min - padding,
+      max: max + padding,
+      tickInterval: padding * 0.4,
+      tickCount: DEFAULT_TICK_COUNT,
+    };
+  }
+
+  const range = max - min;
+  const roughInterval = range / (targetTickCount - 1);
+
+  // Guard against near-zero roughInterval caused by floating-point precision.
+  if (roughInterval < 1e-10) {
+    return { min: min - 1, max: max + 1, tickInterval: 0.5, tickCount: 4 };
+  }
+
+  const magnitude = Math.pow(10, Math.floor(Math.log10(roughInterval)));
+  const normalized = roughInterval / magnitude;
+
+  const preferLargerInterval = options?.preferLargerInterval ?? false;
+  let selectedMultiple = preferLargerInterval
+    ? getCeilCanonicalMultiple(normalized)
+    : getNearestCanonicalMultiple(normalized);
+
+  // For the default 6-tick target (5 sections), stay in the 1/2/2.5
+  // progression for improved readability.
+  if (targetTickCount === DEFAULT_TICK_COUNT && normalized <= 2.5) {
+    selectedMultiple = getCeilCanonicalMultiple(normalized);
+  }
+
+  const niceInterval = selectedMultiple * magnitude;
+  const niceMin = Math.floor(min / niceInterval) * niceInterval;
+  const niceMax = Math.ceil(max / niceInterval) * niceInterval;
+  const actualTickCount = Math.round((niceMax - niceMin) / niceInterval) + 1;
+
+  return { min: niceMin, max: niceMax, tickInterval: niceInterval, tickCount: actualTickCount };
+};
+
+/**
+ * Scan all series data to derive stable X/Y axis bounds and section counts.
+ *
+ * Key behaviours:
+ * - Caps X sections at 5 regardless of chart width to stay readable.
+ * - Detects low-cardinality near-uniform X domains and uses unique bucket
+ *   count instead of tick math (avoids a trailing empty section).
+ * - Snaps near-integer X values (tolerance 0.15) into integer domains for
+ *   categorical-like scatter data.
+ * - Applies float tolerance (1e-6) to prevent precision noise creating
+ *   phantom buckets.
+ * - Uses preferLargerInterval for Y to avoid odd steps (e.g. 26/52/78).
+ */
+export const computeAxisSections = (
+  series: TSeries[],
+  chartWidthPx?: number,
+): TAxisSections => {
+  if (!series || series.length === 0) return { ...DEFAULT_AXIS_RESULT };
+
+  let minX = Infinity,
+    maxX = -Infinity,
+    minY = Infinity,
+    maxY = -Infinity;
+  const xValues: number[] = [];
+
+  for (const s of series) {
+    for (const point of s.data) {
+      if (point.x < minX) minX = point.x;
+      if (point.x > maxX) maxX = point.x;
+      if (point.y < minY) minY = point.y;
+      if (point.y > maxY) maxY = point.y;
+      xValues.push(point.x);
+    }
+  }
+
+  // Deduplicate with float-tolerance normalisation.
+  const uniqueSortedXValues = Array.from(
+    new Set(
+      xValues.map((v) => {
+        const rounded = Math.round(v);
+        return (Math.abs(v - rounded) <= CHART_CONFIG.axis.floatTolerance
+          ? rounded
+          : v
+        ).toFixed(6);
+      }),
+    ),
+  )
+    .map(Number)
+    .sort((a, b) => a - b);
+
+  // Integer-snap pass (wider tolerance 0.15).
+  const integerSnappedXValues = xValues.map((v) => {
+    const nearest = Math.round(v);
+    return Math.abs(v - nearest) <= CHART_CONFIG.axis.integerSnapTolerance
+      ? nearest
+      : v;
+  });
+  const allNearIntegers = integerSnappedXValues.every(
+    (snapped, i) =>
+      Math.abs(snapped - xValues[i]) <= CHART_CONFIG.axis.integerSnapTolerance,
+  );
+  const uniqueSortedSnapped = Array.from(new Set(integerSnappedXValues)).sort(
+    (a, b) => a - b,
+  );
+
+  const isLowCardinalityUniform =
+    uniqueSortedXValues.length >= 2 &&
+    uniqueSortedXValues.length <= CHART_CONFIG.axis.maxSections + 1 &&
+    isNearUniformSpacing(uniqueSortedXValues);
+
+  const useIntegerSnappedDomain =
+    allNearIntegers &&
+    uniqueSortedSnapped.length >= 2 &&
+    uniqueSortedSnapped.length <= CHART_CONFIG.axis.maxSections + 1 &&
+    isNearUniformSpacing(uniqueSortedSnapped);
+
+  const xDomainMin = useIntegerSnappedDomain
+    ? uniqueSortedSnapped[0]
+    : isLowCardinalityUniform
+      ? uniqueSortedXValues[0]
+      : minX;
+
+  const xDomainMax = useIntegerSnappedDomain
+    ? uniqueSortedSnapped[uniqueSortedSnapped.length - 1]
+    : isLowCardinalityUniform
+      ? uniqueSortedXValues[uniqueSortedXValues.length - 1]
+      : maxX;
+
+  // Cap tick-count estimation to the same section cap used for rendering so
+  // wide screens don't request more ticks than will be rendered.
+  const xTargetTickCount = Math.min(
+    getTargetTickCountByWidth(chartWidthPx ?? 0),
+    MAX_X_TICKS_FROM_SECTION_CAP,
+  );
+
+  const xAxis = normalizeAxis(xDomainMin, xDomainMax, xTargetTickCount);
+  const yAxis = normalizeAxis(minY, maxY, CHART_CONFIG.axis.maxSections + 1, {
+    preferLargerInterval: true,
+  });
+
+  const xRawSections = useIntegerSnappedDomain
+    ? uniqueSortedSnapped.length - 1
+    : isLowCardinalityUniform
+      ? uniqueSortedXValues.length - 1
+      : Math.max(
+          CHART_CONFIG.axis.minXSections,
+          Math.min(CHART_CONFIG.axis.maxSections, xAxis.tickCount - 1),
+        );
+
+  const xSections = Math.max(
+    CHART_CONFIG.axis.minXSections,
+    Math.min(xRawSections, getIntegerDomainSectionCap(xDomainMin, xDomainMax)),
+  );
+
+  const ySections = Math.max(
+    CHART_CONFIG.axis.minYSections,
+    Math.min(CHART_CONFIG.axis.maxSections, yAxis.tickCount - 1),
+  );
+
+  return {
+    xSections,
+    ySections,
+    yAxis,
+    xLabelsAsIntegers: useIntegerSnappedDomain,
+    dataBounds: {
+      x: { min: xDomainMin, max: xDomainMax },
+      y: { min: minY, max: maxY },
+    },
+  };
+};
+
+/**
+ * Convert TAxisSections into the explicit layout props that BubbleChart
+ * expects: minX, maxX, xNoOfSections, xStepValue, initialSpacing,
+ * endSpacing, spacing.
+ *
+ * Edge spacings are sized to the first/last bubble radius so bubbles are
+ * never clipped at the chart boundary.
+ */
+export const getNormalizedXAxisLayout = ({
+  normalizedAxes,
+  series,
+  bubbleMode,
+  chartWidth,
+  minBubbleRadius,
+  maxBubbleRadius,
+}: TXAxisLayoutInput): TXAxisLayout => {
+  const xNoOfSections = Math.max(1, normalizedAxes.xSections);
+
+  const domain = normalizedAxes.xLabelsAsIntegers
+    ? {
+        min: Math.round(normalizedAxes.dataBounds.x.min),
+        max: Math.round(normalizedAxes.dataBounds.x.max),
+        tickInterval: Math.max(
+          1,
+          (Math.round(normalizedAxes.dataBounds.x.max) -
+            Math.round(normalizedAxes.dataBounds.x.min)) /
+            xNoOfSections,
+        ),
+      }
+    : {
+        min: normalizedAxes.dataBounds.x.min,
+        max: normalizedAxes.dataBounds.x.max,
+        tickInterval:
+          (normalizedAxes.dataBounds.x.max - normalizedAxes.dataBounds.x.min) /
+          xNoOfSections,
+      };
+
+  const xAxisMin = domain.min;
+  const xStepValue = domain.tickInterval;
+  const xAxisMax = xAxisMin + xStepValue * xNoOfSections;
+
+  const edgeSpacing = getEdgeSpacing(
+    series,
+    bubbleMode,
+    minBubbleRadius,
+    maxBubbleRadius,
+  );
+
+  const spacing =
+    xNoOfSections > 0
+      ? Math.max(
+          0,
+          (chartWidth - edgeSpacing.initialSpacing - edgeSpacing.endSpacing) /
+            xNoOfSections,
+        )
+      : chartWidth;
+
+  return {
+    xAxisMin,
+    xAxisMax,
+    xNoOfSections,
+    xStepValue,
+    xAxisOffset: xAxisMin,
+    initialSpacing: edgeSpacing.initialSpacing,
+    endSpacing: edgeSpacing.endSpacing,
+    spacing,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Edge-spacing helpers (used by getNormalizedXAxisLayout)
+// ---------------------------------------------------------------------------
+
+const getFirstBubbleRadius = (
+  series: TSeries[],
+  minBubbleRadius: number,
+  maxBubbleRadius: number,
+): number => {
+  for (const s of series) {
+    const first = s.data[0];
+    if (!first) continue;
+    const raw = first.r ?? minBubbleRadius;
+    return Math.max(minBubbleRadius, Math.min(maxBubbleRadius, raw));
+  }
+  return minBubbleRadius;
+};
+
+const getEdgeSpacing = (
+  series: TSeries[],
+  bubbleMode: boolean,
+  minBubbleRadius: number,
+  maxBubbleRadius: number,
+): { initialSpacing: number; endSpacing: number } => {
+  if (!bubbleMode) {
+    return { initialSpacing: minBubbleRadius, endSpacing: minBubbleRadius };
+  }
+
+  const initialSpacing =
+    getFirstBubbleRadius(series, minBubbleRadius, maxBubbleRadius) +
+    CHART_CONFIG.spacing.bubbleBuffer;
+
+  const reversedSeries: TSeries[] = [...series]
+    .reverse()
+    .map((s) => ({ ...s, data: [...s.data].reverse() }));
+
+  const endSpacing =
+    getFirstBubbleRadius(reversedSeries, minBubbleRadius, maxBubbleRadius) +
+    CHART_CONFIG.spacing.bubbleBuffer;
+
+  return { initialSpacing, endSpacing };
+};
+
+// ---------------------------------------------------------------------------
+// Remaining public utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Prevent floating-point noise in axis label strings by rounding to a
+ * precision derived from the tick interval (one extra decimal beyond
+ * interval precision). Rounds to integer when the domain is integer-like.
+ */
+export const normalizeAxisLabelValue = ({
+  value,
+  tickInterval,
+  labelsAsIntegers = false,
+}: TAxisLabelNormalizationInput): string => {
+  const parsed = parseFloat(value);
+  if (!Number.isFinite(parsed)) return value;
+  if (labelsAsIntegers) return String(Math.round(parsed));
+
+  const decimals = getDecimalsFromInterval(tickInterval);
+  return decimals === 0 ? String(Math.round(parsed)) : parsed.toFixed(decimals);
+};
+
+/**
+ * Determine whether the chart renders in bubble mode (variable radius) or
+ * scatter mode (fixed-size dots).
+ *
+ * An explicit `chartType` prop takes precedence; otherwise the mode is
+ * inferred from whether any data point carries an `r` property.
+ */
+export const getBubbleMode = (
+  series: TSeries[],
+  chartType?: 'bubble' | 'scatter',
+): boolean => {
+  if (chartType) return chartType === 'bubble';
+  return (
+    Array.isArray(series) &&
+    series.some((s) => s.data.some((p) => p.r !== undefined))
+  );
+};
+
+/**
+ * Snap a point's X coordinate to the nearest integer when the domain was
+ * detected as integer-like, ensuring placement stays aligned with integer
+ * axis ticks.
+ */
+export const getRenderedXValue = (
+  x: number,
+  xLabelsAsIntegers: boolean,
+): number => {
+  if (!xLabelsAsIntegers) return x;
+  const nearest = Math.round(x);
+  return Math.abs(x - nearest) <= CHART_CONFIG.axis.integerSnapTolerance
+    ? nearest
+    : x;
+};
+
+/**
+ * Radius-aware label truncation for in-bubble text.
+ *
+ * In bubble mode the maximum character count scales with the bubble radius
+ * so labels never overflow the bubble boundary.  In scatter mode a fixed
+ * compact rule is applied (first 3 chars + "…").  Returns an empty string
+ * if the bubble is too small to show any meaningful label.
+ */
+export const formatLabel = (
+  label: string,
+  radius: number,
+  isBubbleMode: boolean,
+): string => {
+  if (!isBubbleMode) {
+    return label.length > 4 ? `${label.substring(0, 3)}...` : label;
+  }
+
+  const effectiveRadius = radius + CHART_CONFIG.label.radiusBuffer;
+  const maxChars = Math.max(
+    CHART_CONFIG.label.minChars,
+    Math.floor(effectiveRadius * CHART_CONFIG.label.charsPerRadiusUnit),
+  );
+
+  if (label.length <= maxChars) return label;
+
+  const truncateAt = maxChars - 3;
+  if (truncateAt < CHART_CONFIG.label.minChars) return '';
+
+  return `${label.substring(0, truncateAt)}...`;
+};


### PR DESCRIPTION
# feat(BubbleChart): stable axis normalisation and edge spacing for bubble/scatter charts

## Summary

This PR adds a self-contained `bubbleChartUtils` module and wires it into
`useBubbleChart` as smarter defaults for axis layout. All existing explicit
props continue to work exactly as before — the new utilities only apply when
the caller has not provided their own values.

### Problems addressed

| Symptom | Root cause |
|---|---|
| Y-axis shows "odd" steps like 26 / 52 / 78 | Raw `maxY / yNoOfSections` produces non-canonical intervals |
| First / last bubble clipped at the chart edge | `initialSpacing` / `endSpacing` default to fixed pixel constants regardless of bubble radius |
| X sections drift on wide screens | Tick-count estimation is uncapped, then rendering clamps to 5, desynchronising the two |
| Near-integer X values (e.g. 1.02, 2.01) produce fractional axis labels | No integer-snap detection in the existing label logic |
| Float precision creates phantom X buckets (e.g. 1.0000000001 ≠ 1) | No float tolerance in uniqueness check |

### What changed

**New file — `src/utils/bubbleChartUtils.ts`** (no external dependencies)

| Export | Purpose |
|---|---|
| `normalizeAxis` | "Nice number" tick intervals (1 / 2 / 2.5 / 5 / 10 progression) |
| `computeAxisSections` | Scan multi-series data → stable X/Y bounds + tick counts |
| `getNormalizedXAxisLayout` | Produce explicit `initialSpacing`, `endSpacing`, `spacing`, `xNoOfSections`, `xStepValue` from series data and container width |
| `normalizeAxisLabelValue` | Interval-aware decimal rounding for axis label strings |
| `getBubbleMode` | Infer bubble vs scatter from data shape or explicit `scatterChart` prop |
| `getRenderedXValue` | Integer-snap a point's X coordinate when the domain is categorical |
| `formatLabel` | Radius-proportional label truncation for in-bubble text |

**New file — `src/utils/bubbleChartUtils.test.ts`**

17 deterministic, dependency-free test cases covering all exports and all
branch conditions (empty series, float tolerance, integer-snap, scatter vs
bubble edge spacing, wide vs narrow width, etc.).

**Modified — `src/BubbleChart/index.tsx`**

Three lines changed to use derived values as fallbacks:

```diff
-  const initialSpacing = props.initialSpacing ?? BubbleDefaults.initialSpacing;
-  const spacing = props.spacing ?? (props.width ? props.width / xNoOfSections : LineDefaults.spacing);
-  const endSpacing = props.endSpacing ?? BubbleDefaults.endSpacing;
+  const initialSpacing = props.initialSpacing ?? derivedXLayout.initialSpacing;
+  const spacing = props.spacing ?? (props.width ? derivedXLayout.spacing : LineDefaults.spacing);
+  const endSpacing = props.endSpacing ?? derivedXLayout.endSpacing;
```

Plus `xNoOfSections` now uses the derived section count when not provided
explicitly, and the `seriesForAxisCalc` / `derivedAxes` / `derivedXLayout`
block is inserted after `minRadius` / `maxRadius` are resolved.

## Files changed

```
ADD    src/utils/bubbleChartUtils.ts        (pure math, ~270 lines)
ADD    src/utils/bubbleChartUtils.test.ts   (17 test cases, ~290 lines)
MODIFY src/BubbleChart/index.tsx            (~40 lines added, 3 lines changed)
```

## Backwards compatibility

- All existing `BubbleChartPropsType` props continue to work unchanged.
- Explicit `initialSpacing`, `endSpacing`, `spacing`, `xNoOfSections`,
  `xStepValue`, `minX`, `maxX` props take precedence over derived values
  (standard `??` fallback pattern, same as the rest of the hook).
- `scatterChart` prop is already present in `BubbleChartPropsType` (v1.4.76).
- No new props, no new peer dependencies.

## Testing

```bash
# From the gifted-charts-core package root:
jest src/utils/bubbleChartUtils.test.ts
```

All 17 cases pass with zero mocks.
